### PR TITLE
Restore Map Visualization Feature

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,13 +3,48 @@ document.addEventListener('DOMContentLoaded', () => {
     const AppState = {
         festivals: [],
         filteredFestivals: [],
-        view: 'tasks', // 'tasks' (Next 30 days) or 'all'
+        view: 'tasks', // 'tasks', 'all', or 'map'
+        previousView: 'tasks',
         selectedMonth: null,
         searchTerm: ''
     };
 
+    let mapInstance = null;
+    let mapMarkers = [];
+
+    const PROVINCE_COORDS = {
+        "BUENOS AIRES": [-36.6769, -60.5588],
+        "CIUDAD DE BUENOS AIRES": [-34.6037, -58.3816],
+        "CABA": [-34.6037, -58.3816],
+        "CATAMARCA": [-28.4696, -65.7852],
+        "CHACO": [-26.3868, -60.7653],
+        "CHUBUT": [-43.3002, -68.5247],
+        "CÓRDOBA": [-31.4201, -64.1888],
+        "CORRIENTES": [-28.4651, -58.8308],
+        "ENTRE RÍOS": [-31.7747, -60.4956],
+        "FORMOSA": [-26.1775, -58.1781],
+        "JUJUY": [-24.1858, -65.2995],
+        "LA PAMPA": [-36.6148, -64.2839],
+        "LA RIOJA": [-29.4111, -66.8507],
+        "MENDOZA": [-32.8895, -68.8458],
+        "MISIONES": [-27.3671, -55.8961],
+        "NEUQUÉN": [-38.9516, -68.0617],
+        "RÍO NEGRO": [-40.8135, -63.0036],
+        "SALTA": [-24.7821, -65.4232],
+        "SAN JUAN": [-31.5375, -68.5364],
+        "SAN LUIS": [-33.2950, -66.3356],
+        "SANTA CRUZ": [-48.8154, -69.9554],
+        "SANTA FE": [-31.6107, -60.6973],
+        "SANTIAGO DEL ESTERO": [-27.7834, -64.2642],
+        "TIERRA DEL FUEGO": [-54.8019, -68.3030],
+        "TIERRA DEL FUEGO, ANTÁRTIDA E ISLAS DEL ATLÁNTICO SUR": [-54.8019, -68.3030],
+        "TUCUMÁN": [-26.8241, -65.2226],
+        "ISLA APIPE GRANDE": [-27.5, -56.7]
+    };
+
     // DOM Elements
     const festivalsGrid = document.getElementById('festivals-grid');
+    const mapView = document.getElementById('map-view');
     const searchInput = document.getElementById('search-input');
     const monthChips = document.getElementById('month-chips');
     const viewTitle = document.getElementById('view-title');
@@ -17,6 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const viewTasksBtn = document.getElementById('view-tasks-btn');
     const viewAllBtn = document.getElementById('view-all-btn');
+    const viewMapBtn = document.getElementById('view-map-btn');
     const floatingAddBtn = document.getElementById('floating-add-btn');
 
     // Modal Elements
@@ -59,7 +95,15 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- RENDER FUNCTIONS ---
     function render() {
         filterData();
-        renderGrid();
+        if (AppState.view === 'map') {
+            festivalsGrid.classList.add('hidden');
+            mapView.classList.remove('hidden');
+            renderMap();
+        } else {
+            festivalsGrid.classList.remove('hidden');
+            mapView.classList.add('hidden');
+            renderGrid();
+        }
         updateUIState();
     }
 
@@ -121,6 +165,98 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     }
+
+    function normalizeProvince(prov) {
+        if (!prov) return "";
+        let p = prov.toUpperCase().trim();
+        if (p === "CIUDAD AUTÓNOMA DE BUENOS AIRES") return "CABA";
+        if (p === "CIUDAD DE BUENOS AIRES") return "CABA";
+        // Handle "Provincia de ..."
+        p = p.replace("PROVINCIA DE ", "");
+        return p;
+    }
+
+    function renderMap() {
+        if (!mapInstance) {
+            mapInstance = L.map('map-container').setView([-38.4161, -63.6167], 4);
+            L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+                attribution: '© OpenStreetMap contributors'
+            }).addTo(mapInstance);
+        }
+
+        // Clear existing markers
+        mapMarkers.forEach(m => mapInstance.removeLayer(m));
+        mapMarkers = [];
+
+        // Group festivals by province to avoid overlapping markers
+        const byProvince = {};
+        AppState.filteredFestivals.forEach(f => {
+            const prov = normalizeProvince(f.province);
+            if (!byProvince[prov]) byProvince[prov] = [];
+            byProvince[prov].push(f);
+        });
+
+        Object.entries(byProvince).forEach(([prov, fests]) => {
+            const coords = PROVINCE_COORDS[prov];
+            if (coords) {
+                const count = fests.length;
+
+                // Color based on most "advanced" status
+                let markerColor = '#475569'; // Default Pendiente/Discarted
+                if (fests.some(f => f.status === 'Exito')) markerColor = '#22c55e';
+                else if (fests.some(f => f.status === 'Seguimiento')) markerColor = '#eab308';
+                else if (fests.some(f => f.status === 'Descartado')) markerColor = '#ef4444';
+
+                const marker = L.circleMarker(coords, {
+                    radius: Math.min(10 + (count * 1.5), 25),
+                    fillColor: markerColor,
+                    color: "#fff",
+                    weight: 2,
+                    opacity: 1,
+                    fillOpacity: 0.9
+                }).addTo(mapInstance);
+
+                const popupContent = `
+                    <div class="text-slate-900 p-3 min-w-[200px]">
+                        <h4 class="font-black text-sm border-b border-slate-200 pb-2 mb-2 uppercase tracking-tight">
+                            ${prov} <span class="text-slate-400 ml-1">(${count} eventos)</span>
+                        </h4>
+                        <div class="max-h-60 overflow-y-auto pr-2 custom-scrollbar-light">
+                            ${fests.map(f => {
+                                let statusDot = '⚪';
+                                if (f.status === 'Exito') statusDot = '🟢';
+                                else if (f.status === 'Seguimiento') statusDot = '🟡';
+                                else if (f.status === 'Descartado') statusDot = '🔴';
+
+                                return `
+                                <div class="mb-3 last:mb-0 pb-2 border-b border-slate-50 last:border-0 cursor-pointer hover:bg-slate-50 p-1 rounded transition" onclick="window.appOpenModalById(${f.id})">
+                                    <div class="flex justify-between items-start gap-2">
+                                        <span class="font-bold text-xs leading-tight">${f.name}</span>
+                                        <span class="text-[10px] shrink-0">${statusDot}</span>
+                                    </div>
+                                    <div class="text-[10px] text-slate-500 mt-1">
+                                        ${f.day || '??'} ${MONTH_NAMES[f.month - 1]} • ${f.location}
+                                    </div>
+                                </div>
+                                `;
+                            }).join('')}
+                        </div>
+                    </div>
+                `;
+                marker.bindPopup(popupContent);
+                mapMarkers.push(marker);
+            }
+        });
+
+        // Trigger map resize to ensure it renders correctly after being hidden
+        setTimeout(() => mapInstance.invalidateSize(), 100);
+    }
+
+    // Expose openModal to global scope for popup clicks
+    window.appOpenModalById = (id) => {
+        const f = AppState.festivals.find(fest => fest.id === id);
+        if (f) openModal(f);
+    };
 
     function createCard(f) {
         const div = document.createElement('div');
@@ -191,18 +327,23 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateUIState() {
+        [viewTasksBtn, viewAllBtn, viewMapBtn].forEach(btn => {
+            btn.classList.remove('bg-green-500', 'text-[#0f172a]');
+            btn.classList.add('bg-slate-800', 'text-slate-300');
+        });
+
         if (AppState.view === 'tasks') {
             viewTasksBtn.classList.add('bg-green-500', 'text-[#0f172a]');
-            viewTasksBtn.classList.remove('bg-slate-800', 'text-green-400');
-            viewAllBtn.classList.add('bg-slate-800', 'text-slate-300');
-            viewAllBtn.classList.remove('bg-green-500', 'text-[#0f172a]');
+            viewTasksBtn.classList.remove('bg-slate-800', 'text-slate-300');
             viewTitle.textContent = "Próximos Eventos (Pendientes)";
-        } else {
+        } else if (AppState.view === 'all') {
             viewAllBtn.classList.add('bg-green-500', 'text-[#0f172a]');
             viewAllBtn.classList.remove('bg-slate-800', 'text-slate-300');
-            viewTasksBtn.classList.add('bg-slate-800', 'text-green-400');
-            viewTasksBtn.classList.remove('bg-green-500', 'text-[#0f172a]');
             viewTitle.textContent = AppState.selectedMonth ? `Eventos de ${MONTH_NAMES[AppState.selectedMonth - 1]}` : "Todos los Eventos";
+        } else if (AppState.view === 'map') {
+            viewMapBtn.classList.add('bg-green-500', 'text-[#0f172a]');
+            viewMapBtn.classList.remove('bg-slate-800', 'text-slate-300');
+            viewTitle.textContent = "Mapa de Festivales";
         }
     }
 
@@ -251,6 +392,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
         viewAllBtn.addEventListener('click', () => {
             AppState.view = 'all';
+            render();
+        });
+
+        viewMapBtn.addEventListener('click', () => {
+            if (AppState.view !== 'map') {
+                AppState.previousView = AppState.view;
+                AppState.view = 'map';
+            } else {
+                AppState.view = AppState.previousView || 'tasks';
+            }
             render();
         });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DK Fest Tracker v2</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
     <style>
         body {
@@ -12,6 +14,7 @@
             background-color: #0f172a;
             color: #f1f5f9;
         }
+        #map-container { height: 600px; width: 100%; border-radius: 1.5rem; border: 1px solid #334155; }
         .status-Exito { background-color: #166534; border-color: #22c55e; }
         .status-Seguimiento { background-color: #854d0e; border-color: #eab308; }
         .status-Descartado { background-color: #991b1b; border-color: #ef4444; }
@@ -44,9 +47,14 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
                     </svg>
                 </button>
-                <button id="view-all-btn" class="p-2 rounded-full bg-slate-800 text-slate-300 hover:bg-slate-700">
+                <button id="view-all-btn" class="p-2 rounded-full bg-slate-800 text-slate-300 hover:bg-slate-700" title="Ver Lista">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />
+                    </svg>
+                </button>
+                <button id="view-map-btn" class="p-2 rounded-full bg-slate-800 text-slate-300 hover:bg-slate-700" title="Ver Mapa">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
                     </svg>
                 </button>
             </div>
@@ -88,9 +96,14 @@
         <!-- Dynamic Content Title -->
         <h2 id="view-title" class="text-2xl font-black mb-4 px-2">Próximos 30 Días</h2>
 
-        <!-- Grid of Cards -->
+        <!-- Grid View -->
         <div id="festivals-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <!-- Cards will be injected here -->
+        </div>
+
+        <!-- Map View -->
+        <div id="map-view" class="hidden">
+            <div id="map-container"></div>
         </div>
 
         <!-- No Results -->


### PR DESCRIPTION
I have restored the map visualization feature for the DK Fest Tracker. This feature allows users to view festivals geographically, grouped by province.

Key changes:
- **Leaflet.js Integration**: Added necessary CSS and JS links to the main template.
- **Map View Logic**: Restored the `renderMap` function in `app.js`, which handles marker placement using a predefined `PROVINCE_COORDS` constant.
- **Interactive Markers**: Markers are color-coded based on event status and show detailed popups. Users can open the edit modal directly from a map popup.
- **UI Toggle**: Added a map icon to the header to switch between the task/list view and the map view.
- **Normalization**: Added province name normalization to ensure consistent mapping even with variations in data entry.

The changes were verified visually using Playwright to ensure correct rendering and interaction.

---
*PR created automatically by Jules for task [10035601165956938254](https://jules.google.com/task/10035601165956938254) started by @dkmanled*